### PR TITLE
Use ZSTR_IS_INTERNED

### DIFF
--- a/php_array.h
+++ b/php_array.h
@@ -370,7 +370,7 @@ char *php_array_zval_to_string(zval *z, int *plen, zend_bool *pfree) {
 			zval_copy_ctor(&c);
 			convert_to_string(&c);
 #ifdef ZEND_ENGINE_3
-			*pfree = ! IS_INTERNED(Z_STR(c));
+			*pfree = ! ZSTR_IS_INTERNED(Z_STR(c));
 #else
 			*pfree = ! IS_INTERNED(Z_STRVAL(c));
 #endif


### PR DESCRIPTION
The old macro is removed in php/php-src@64e2832bc8065f24c4d273075608f33826c71fd8

The new macro was introduced in php/php-src@4bd22cf1c1d6a262fe2f026e082f2565433c53df and has been available since PHP 7.0

----

This is based on @remicollet's PR: https://github.com/mongodb/mongo-php-driver/pull/1849